### PR TITLE
clearing console after all has renderd and loaded,

### DIFF
--- a/app/scripts/views/app.coffee
+++ b/app/scripts/views/app.coffee
@@ -64,7 +64,11 @@ define [
       'click': 'bodyClicked'
 
     render: ->
-      console.clear()
+      if window.location.hostname == 'localhost'
+        setTimeout -> 
+          console.clear()
+        , 2000 
+      # console.clear()
       @$el.html @template()
       @renderPersistentSubviews()
       # @configureFieldDB() # FieldDB stuff commented out until it can be better incorporated


### PR DESCRIPTION
clearing console after all has rendered and loaded, if on a development machine.

We want dative to be the interface for power users, so if a user opens the console, we want to great them and tell them how to run and find code in the branded library. the banner was also there for devs so they could know how to look into the library, but it gets in the way if you dont want to scroll the console to debug.