### PR TITLE
only need grunt browserify:src

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,6 @@ before_install:
   - npm install -g grunt-cli
   - npm install -g bower
   - npm install -g jasmine-node
-  - npm install d3
-  - npm install node-jsdom
   - npm install
   - bower install
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,8 @@ before_install:
   - npm install -g grunt-cli
   - npm install -g bower
   - npm install -g jasmine-node
+  - npm install d3
+  - npm install node-jsdom
   - npm install
   - bower install
 

--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -485,7 +485,7 @@ module.exports = (grunt) ->
           ' git checkout master;' +
           ' git pull cesine master;' +
           ' npm install; ' +
-          ' grunt browserify; ' +
+          ' grunt browserify:src; ' +
           ' fi '
 
     rev:


### PR DESCRIPTION
the travis build is failing because its running `grunt browserify` which now fails if you don't have optional dependancies installed because browserify is not honoring the optionality of d3 in the case of browserifiying the test suite (which doesnt need to run in order for for dative to build)