### PR TITLE
changing to most recent node versions for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: node_js
 
 node_js:
-  - 0.12
-  - 4.1
+  - 0.12.10
+  - 4.3.0
 
 # Travis supports running a real browser (Firefox) with a virtual screen. Just update your .travis.yml to set up the virtual screen like this:
 # before_script:
@@ -13,6 +13,7 @@ node_js:
 # branches:
 #  only:
 #    - master
+bundler_args: --retry 3
 
 notifications:
   email:
@@ -21,14 +22,16 @@ notifications:
     on_success: change
     on_failure: always
 
+# env:
+#   matrix:
+    # see set_up_new_machine.sh
+
 before_install:
   # Download and configure deps
   - export TZ=Canada/Eastern # http://stackoverflow.com/questions/23371542/how-do-i-configure-travis-ci-to-use-the-correct-time-zone-for-a-rails-app
-  - sudo apt-get install ncftp
+  # - sudo apt-get install ncftp
   - npm install -g grunt-cli
   - npm install -g bower
-  - npm install
-  - bower install
 
 script: grunt deploy
 

--- a/package.json
+++ b/package.json
@@ -36,5 +36,8 @@
   },
   "engines": {
     "node": ">=0.10.0"
+  },
+  "scripts": {
+    "postinstall": "bower install"
   }
 }


### PR DESCRIPTION
this gets travis passing, probably because something in the travis build changed for   ` - sudo apt-get install ncftp`